### PR TITLE
Use &str instead of String for filenames

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -9,7 +9,7 @@ pub struct Args {
     /// File to run.
     /// If not given, defaults to stdin, which does not mean a REPL,
     /// rather the code will be read from stdin all at once and then run.
-    pub filename: Option<String>,
+    pub filename: Option<&str>,
 
     /// Level to log messages at
     #[arg(value_enum, short, long, default_value_t = LogLevel::Off)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
     let lexer = Lexer::new(
         stream,
         match args.filename {
-            None => String::from("<stdin>"),
+            None => "<stdin>",
             Some(f) => f,
         },
     );

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -12,13 +12,13 @@ pub enum ErrorKind {
 }
 
 /// Struct to represent an error
-pub struct Error {
+pub struct Error<'a> {
     pub kind: ErrorKind,
     pub msg: String,
-    pub pos: Option<Position>,
+    pub pos: Option<Position<'a>>,
 }
 
-impl Display for Error {
+impl Display for Error<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -34,14 +34,14 @@ impl Display for Error {
 }
 
 // TODO: impl From
-impl Error {
+impl Error<'_> {
     /// Create a new [`Error`] from an [`io::ErrorKind`]
     /// at `pos` reading from `filename`
-    pub fn from_std_io_errorkind(
+    pub fn from_std_io_errorkind<'a>(
         io_errorkind: io::ErrorKind,
-        pos: Option<Position>,
-        filename: &str,
-    ) -> Error {
+        pos: Option<Position<'a>>,
+        filename: &'a str,
+    ) -> Error<'a> {
         match io_errorkind {
             io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied => {
                 let kind: ErrorKind;

--- a/crates/core/src/lexer.rs
+++ b/crates/core/src/lexer.rs
@@ -7,24 +7,24 @@ use crate::position::Position;
 use crate::token::Token;
 
 /// Struct to transform input into [`Token`]s
-pub struct Lexer {
+pub struct Lexer<'a> {
     /// Stream that we are reading our input from
     stream: Box<dyn Read>,
     /// Character that we are currently processing
     current_char: Option<char>,
     /// Our position in the text we are lexing
-    pos: Position,
+    pos: Position<'a>,
     /// The file name that we are lexing
-    filename: String,
+    filename: &'a str,
 }
 
-impl Lexer {
+impl<'a> Lexer<'a> {
     /// Create a new [`Lexer`]
-    pub fn new(stream: Box<dyn Read>, filename: String) -> Self {
+    pub fn new(stream: Box<dyn Read>, filename: &'a str) -> Lexer<'a> {
         Self {
             stream,
             current_char: None,
-            pos: Position::start(filename.clone()),
+            pos: Position::start(filename),
             filename,
         }
     }
@@ -32,12 +32,20 @@ impl Lexer {
     /// Transform into [`Vec<Token>`].
     /// Returns `Err` if we could not parse the input stream.
     /// Access the [`Error`]'s `kind` field for more details
-    pub fn lex(&mut self) -> Result<Vec<Token>, Error> {
+    pub fn lex(&'a mut self) -> Result<Vec<Token>, Error> {
         let mut tokens = Vec::new();
 
-        while self.current_char.is_some() {
-            self.advance()?;
-            // TODO: lex
+        loop {
+            // TODO: fix
+            self.advance()?; // mutable borrow
+                             // Lexer::advance(&mut self)?;
+                             // TODO: lex
+
+            // immutable borrow
+            // Option::is_none(&self.current_char)
+            if self.current_char.is_none() {
+                break;
+            }
         }
 
         Ok(tokens)

--- a/crates/core/src/position.rs
+++ b/crates/core/src/position.rs
@@ -77,4 +77,11 @@ mod tests {
         assert_eq!(pos.column, 0);
         assert_eq!(pos.line, 2);
     }
+
+    #[test]
+    fn test_display() {
+        let pos = Position::start("filename".to_string());
+
+        assert_eq!(pos.to_string(), "filename:1:1")
+    }
 }

--- a/crates/core/src/position.rs
+++ b/crates/core/src/position.rs
@@ -3,21 +3,21 @@ use std::fmt::Display;
 /// Struct to represent the position we are at in the text
 /// we are lexing
 #[derive(Debug, Clone)]
-pub struct Position {
+pub struct Position<'a> {
     line: usize,
     column: usize,
-    filename: String,
+    filename: &'a str,
 }
 
-impl Display for Position {
+impl Display for Position<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}:{}:{}", self.filename, self.line, self.column)
     }
 }
 
-impl Position {
+impl<'a> Position<'a> {
     /// Return a [`Position`] at the start of a file
-    pub fn start(filename: String) -> Self {
+    pub fn start(filename: &'a str) -> Position<'a> {
         Self {
             line: 1,
             column: 1,
@@ -43,7 +43,7 @@ mod tests {
 
     #[test]
     fn test_start() {
-        let pos = Position::start("filename".to_string());
+        let pos = Position::start("filename");
         assert_eq!(pos.column, 1);
         assert_eq!(pos.line, 1);
         assert_eq!(pos.filename, "filename".to_string())
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     fn test_advance() {
-        let mut pos = Position::start("filename".to_string());
+        let mut pos = Position::start("filename");
         pos.advance('c');
 
         assert_eq!(pos.column, 2);
@@ -59,7 +59,7 @@ mod tests {
 
     #[test]
     fn test_advance_lf() {
-        let mut pos = Position::start("filename".to_string());
+        let mut pos = Position::start("filename");
         pos.advance('c');
         pos.advance('\n');
 
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn test_advance_crlf() {
-        let mut pos = Position::start("filename".to_string());
+        let mut pos = Position::start("filename");
         pos.advance('c');
         pos.advance('\r');
         pos.advance('\n');
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn test_display() {
-        let pos = Position::start("filename".to_string());
+        let pos = Position::start("filename");
 
         assert_eq!(pos.to_string(), "filename:1:1")
     }


### PR DESCRIPTION
- Add test for Position::to_string
- Use &str for filenames instead of String
